### PR TITLE
Add dataset to JaxUtils.

### DIFF
--- a/jaxutils/__init__.py
+++ b/jaxutils/__init__.py
@@ -1,12 +1,37 @@
-from .pytree import PyTree
+# Copyright 2022 The JaxGaussianProcesses Contributors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
 
+
+from .pytree import PyTree
+from .data import Dataset, verify_dataset
+
+__version__ = "0.0.3"
+__authors__ = "Thomas Pinder, Daniel Dodd"
 __license__ = "MIT"
+__emails__ = "tompinder@live.co.uk, d.dodd1@lancaster.ac.uk"
+__license__ = "Apache 2.0"
 __description__ = "Utilities for JAXGaussianProcesses"
 __url__ = "https://github.com/JaxGaussianProcesses/JaxUtils"
 __contributors__ = (
     "https://github.com//JaxGaussianProcesses/JaxUtils/graphs/contributors"
 )
-__version__ = "0.0.2"
 
 
-__all__ = ["PyTree"]
+
+__all__ = [
+    "PyTree",
+    "Dataset",
+    "verify_dataset",
+    ]

--- a/jaxutils/data.py
+++ b/jaxutils/data.py
@@ -1,0 +1,114 @@
+# Copyright 2022 The JaxGaussianProcesses Contributors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+from __future__ import annotations
+
+import jax.numpy as jnp
+from jaxtyping import Array, Float
+from typing import Optional
+
+from .pytree import PyTree
+
+class Dataset(PyTree):
+    """Dataset class."""
+
+    #TODO: Consider HeterotopicDataset and IsotopicDataset abstractions.
+
+    def __init__(
+        self,
+        X: Optional[Float[Array, "N D"]] = None,
+        y: Optional[Float[Array, "N Q"]] = None,
+    ) -> None:
+        """
+        Args:
+            X(Float[Array, "N D"]]): Input data.
+            y(Float[Array, "N Q"]]): Output data.
+
+        Returns:
+            Dataset: A dataset object.
+        """
+
+        _check_shape(X, y)
+        self.X = X
+        self.y = y
+
+    def __repr__(self) -> str:
+        return (
+            f"- Number of datapoints: {self.X.shape[0]}\n- Dimension: {self.X.shape[1]}"
+        )
+
+    def is_supervised(self) -> bool:
+        """Returns True if the dataset is supervised."""
+        return self.X is not None and self.y is not None
+
+    def is_unsupervised(self) -> bool:
+        """Returns True if the dataset is unsupervised."""
+        return self.X is None and self.y is not None
+
+
+    def __add__(self, other: Dataset) -> Dataset:
+        """Combines two datasets into one. The right-hand dataset is stacked beneath left."""
+        x = jnp.concatenate((self.X, other.X))
+        y = jnp.concatenate((self.y, other.y))
+
+        return Dataset(X=x, y=y)
+
+    @property
+    def n(self) -> int:
+        """The number of observations in the dataset."""
+        return self.X.shape[0]
+
+    @property
+    def in_dim(self) -> int:
+        """The dimension of the input data."""
+        return self.X.shape[1]
+
+    @property
+    def out_dim(self) -> int:
+        """The dimension of the output data."""
+        return self.y.shape[1]
+
+    def _add_input(self, X):
+        self.X = X
+        return self
+
+
+def verify_dataset(ds: Dataset) -> None:
+    """Apply a series of checks to the dataset to ensure that downstream operations are safe."""
+    assert ds.X.ndim == 2, (
+        "2-dimensional training inputs are required. Current dimension:"
+        f" {ds.X.ndim}."
+    )
+    if ds.y is not None:
+        assert ds.y.ndim == 2, (
+            "2-dimensional training outputs are required. Current dimension:"
+            f" {ds.y.ndim}."
+        )
+        assert ds.X.shape[0] == ds.y.shape[0], (
+            "Number of inputs must equal the number of outputs. \nCurrent"
+            f" counts:\n- X: {ds.X.shape[0]}\n- y: {ds.y.shape[0]}"
+        )
+
+
+def _check_shape(X: Float[Array, "N D"], y: Float[Array, "N Q"]) -> None:
+    """Checks that the shapes of X and y are compatible."""
+    if X is not None and y is not None:
+        if X.shape[0] != y.shape[0]:
+            raise ValueError(
+                f"X and y must have the same number of rows. Got X.shape={X.shape} and y.shape={y.shape}."
+            )
+
+__all__ = [
+    "Dataset",
+]

--- a/jaxutils/pytree.py
+++ b/jaxutils/pytree.py
@@ -1,4 +1,4 @@
-# Copyright 2022 The JaxLinOp Contributors. All Rights Reserved.
+# Copyright 2022 The JaxGaussianProcesses Contributors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,18 @@
+# Copyright 2022 JaxGaussianProcesses Contributors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
 import io
 import os
 import re

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,7 @@ readme = open("README.md").read()
 REQUIRES = [
     "jax>=0.1.67",
     "jaxlib>=0.1.47",
+    "jaxtyping"
 ]
 
 EXTRAS = {

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,0 +1,69 @@
+# Copyright 2022 The JaxGaussianProcesses Contributors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+import jax.numpy as jnp
+import pytest
+from jaxutils.data import Dataset, verify_dataset
+
+
+@pytest.mark.parametrize("n", [1, 10])
+@pytest.mark.parametrize("outd", [1, 2, 10])
+@pytest.mark.parametrize("ind", [1, 2, 10])
+@pytest.mark.parametrize("n2", [1, 10])
+def test_dataset(n, outd, ind, n2):
+    x = jnp.ones((n, ind))
+    y = jnp.ones((n, outd))
+    d = Dataset(X=x, y=y)
+    verify_dataset(d)
+    assert d.n == n
+    assert d.in_dim == ind
+    assert d.out_dim == outd
+
+    # Test combine datasets.
+    x2 = 2 * jnp.ones((n2, ind))
+    y2 = 2 * jnp.ones((n2, outd))
+    d2 = Dataset(X=x2, y=y2)
+
+    d_combined = d + d2
+    assert d_combined.n == n + n2
+    assert d_combined.in_dim == ind
+    assert d_combined.out_dim == outd
+    assert (d_combined.y[:n] == 1.0).all()
+    assert (d_combined.y[n:] == 2.0).all()
+    assert (d_combined.X[:n] == 1.0).all()
+    assert (d_combined.X[n:] == 2.0).all()
+
+    # Test supervised and unsupervised.
+    assert d.is_supervised() is True
+    dunsup = Dataset(y=y)
+    assert dunsup.is_unsupervised() is True
+
+
+
+
+@pytest.mark.parametrize("nx, ny", [(1, 2), (2, 1), (10, 5), (5, 10)])
+def test_dataset_assertions(nx, ny):
+    x = jnp.ones((nx, 1))
+    y = jnp.ones((ny, 1))
+    
+    with pytest.raises(ValueError):
+        ds = Dataset(X=x, y=y)
+
+
+def test_y_none():
+    x = jnp.ones((10, 1))
+    d = Dataset(X=x)
+    verify_dataset(d)
+    assert d.y is None

--- a/tests/test_pytree.py
+++ b/tests/test_pytree.py
@@ -1,4 +1,4 @@
-# Copyright 2022 The JaxLinOp Contributors. All Rights Reserved.
+# Copyright 2022 The JaxGaussianProcesses Contributors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
This PR adds GPJax's `Dataset` abstraction to JaxUtils, to make code easier to maintain across JaxGaussianProcesses.

- [ ] Bugfix
- [X ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):