### PR TITLE
Add check for 2D dataset inputs

### DIFF
--- a/jaxutils/data.py
+++ b/jaxutils/data.py
@@ -108,6 +108,16 @@ def _check_shape(X: Float[Array, "N D"], y: Float[Array, "N Q"]) -> None:
             raise ValueError(
                 f"X and y must have the same number of rows. Got X.shape={X.shape} and y.shape={y.shape}."
             )
+        
+    if X.ndim != 2:
+        raise ValueError(
+            f"X must be a 2-dimensional array. Got X.ndim={X.ndim}."
+        )
+
+    if y.ndim != 2:
+        raise ValueError(
+            f"y must be a 2-dimensional array. Got y.ndim={y.ndim}."
+        )
 
 __all__ = [
     "Dataset",

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -61,6 +61,18 @@ def test_dataset_assertions(nx, ny):
     with pytest.raises(ValueError):
         ds = Dataset(X=x, y=y)
 
+def test_2d_inputs():
+    x = jnp.ones((5,1)))
+    y = jnp.ones(5)
+
+    with pytest.raises(ValueError):
+        ds = Dataset(X=x, y=y)
+
+    x = jnp.ones(5)
+
+    with pytest.raises(ValueError):
+        ds = Dataset(X=x, y=y)
+        
 
 def test_y_none():
     x = jnp.ones((10, 1))


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Dataset creation currently does not raise an exception when X and y are not 2D.

Issue Number: #2 

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

ValueError is raised when DataSet inputs are not 2D

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
