### PR TITLE
Add priors

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,12 @@
 repos:
+  - repo: https://github.com/PyCQA/autoflake
+    rev: v2.0.0
+    hooks:
+    -   id: autoflake
+        args: ["--in-place", "--remove-unused-variables", "--remove-all-unused-imports", "--recursive"]
+        name: AutoFlake
+        description: "Format with AutoFlake"
+        stages: [commit]
   - repo: https://github.com/psf/black
     rev: 22.3.0
     hooks:
@@ -20,11 +28,8 @@ repos:
         args: [--py37-plus]
       - id: nbqa-flake8
         args: ['--ignore=E501,E203,E302,E402,E731,W503']
-  - repo: https://github.com/PyCQA/autoflake
-    rev: v2.0.0
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
+    rev: 'v0.0.254'
     hooks:
-    -   id: autoflake
-        args: ["--in-place", "--remove-unused-variables", "--remove-all-unused-imports", "--recursive"]
-        name: AutoFlake
-        description: "Format with AutoFlake"
-        stages: [commit]
+      - id: ruff
+        args: ['--fix']

--- a/jaxutils/parameters.py
+++ b/jaxutils/parameters.py
@@ -39,6 +39,7 @@ class Parameters(Pytree, dict):
         params: Dict,
         bijectors: Dict = None,
         trainables: Dict = None,
+        priors: Dict = None,
         training_history=None,
     ):
 
@@ -48,9 +49,13 @@ class Parameters(Pytree, dict):
         if trainables is None:
             trainables = jtu.tree_map(lambda _: True, params)
 
+        if priors is None:
+            priors = jtu.tree_map(lambda _: None, params)
+
         self._param_dict = params
         self._trainable_dict = trainables
         self._bijector_dict = bijectors
+        self._prior_dict = priors
         self._training_history = training_history
 
     def __repr__(self) -> str:
@@ -68,7 +73,11 @@ class Parameters(Pytree, dict):
 
     def update_params(self, value: Dict) -> Parameters:
         return Parameters(
-            value, self.bijectors, self.trainables, self.training_history
+            value,
+            self.bijectors,
+            self.trainables,
+            self.priors,
+            self.training_history,
         )
 
     @property
@@ -77,7 +86,11 @@ class Parameters(Pytree, dict):
 
     def update_bijectors(self, value: Dict) -> Parameters:
         return Parameters(
-            self.params, value, self.trainables, self.training_history
+            self.params,
+            value,
+            self.trainables,
+            self.priors,
+            self.training_history,
         )
 
     @property
@@ -86,7 +99,24 @@ class Parameters(Pytree, dict):
 
     def update_trainables(self, value: Dict) -> Parameters:
         return Parameters(
-            self.params, self.bijectors, value, self.training_history
+            self.params,
+            self.bijectors,
+            value,
+            self.priors,
+            self.training_history,
+        )
+
+    @property
+    def priors(self) -> Dict:
+        return self._prior_dict
+
+    def update_priors(self, value: Dict) -> Parameters:
+        return Parameters(
+            self.params,
+            self.bijectors,
+            self.trainables,
+            value,
+            self.training_history,
         )
 
     @property
@@ -98,6 +128,7 @@ class Parameters(Pytree, dict):
             self.params,
             self.bijectors,
             self.trainables,
+            self.priors,
             value,
         )
 
@@ -109,7 +140,7 @@ class Parameters(Pytree, dict):
         """
         return self.params, self.trainables, self.bijectors
 
-    def constrain(self):
+    def constrain(self) -> Parameters:
         return self.update_params(
             jtu.tree_map(
                 lambda param, trans: trans.forward(param),
@@ -118,7 +149,7 @@ class Parameters(Pytree, dict):
             )
         )
 
-    def unconstrain(self):
+    def unconstrain(self) -> Parameters:
         return self.update_params(
             jtu.tree_map(
                 lambda param, trans: trans.inverse(param),

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -1,0 +1,53 @@
+from jaxutils.parameters import Parameters
+import jax
+import pytest
+import jax.numpy as jnp
+import distrax as dx
+
+
+@pytest.mark.parametrize("jit_compile", [False, True])
+def test_priors(jit_compile):
+    # Vanilla test for case where every parameter has a defined prior
+    param_vals = {"a": jnp.array([1.0]), "b": jnp.array([2.0])}
+    priors = {"a": dx.Normal(0.0, 1.0), "b": dx.Normal(0.0, 1.0)}
+
+    params = Parameters(params=param_vals, priors=priors)
+    if jit_compile:
+        lpd = jax.jit(params.log_prior_density)()
+    else:
+        lpd = params.log_prior_density()
+    assert pytest.approx(lpd, 0.00001) == -4.3378773
+    assert isinstance(lpd, jax.Array)
+
+    # Check fn. works for no priors
+    priors = {"a": None, "b": None}
+    params = Parameters(params=param_vals, priors=priors)
+    if jit_compile:
+        lpd = jax.jit(params.log_prior_density)()
+    else:
+        lpd = params.log_prior_density()
+    assert pytest.approx(lpd, 0.00001) == 0.0
+    assert isinstance(lpd, jax.Array)
+
+    # Check the fn. works for nested structures with incomplete priors
+    param_vals = {
+        "a": jnp.array([1.0]),
+        "b": {"a": jnp.array([10.0]), "b": jnp.array([3.0])},
+    }
+    priors = {"a": None, "b": {"a": dx.Normal(0, 1.0), "b": dx.Gamma(2.0, 2.0)}}
+    params = Parameters(params=param_vals, priors=priors)
+    if jit_compile:
+        lpd = jax.jit(params.log_prior_density)()
+    else:
+        lpd = params.log_prior_density()
+    assert pytest.approx(lpd, 0.00001) == -54.434032
+    assert isinstance(lpd, jax.Array)
+
+    # Check the prior initialising works - by default, there are no priors
+    params = Parameters(param_vals)
+    if jit_compile:
+        lpd = jax.jit(params.log_prior_density)()
+    else:
+        lpd = params.log_prior_density()
+    assert pytest.approx(lpd, 0.00001) == 0.0
+    assert isinstance(lpd, jax.Array)


### PR DESCRIPTION
This PR adds priors into the `Parameters` object and fixes some typing.

## Pull request type

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Currently priors are handled in GPJax. By moving them here, we can offload all the parameter handling to JaxUtils.

Issue Number: N/A

## What is the new behavior?

Priors are treated similarily to bijectors and trainable fields of `Parameters`.